### PR TITLE
Data fetch

### DIFF
--- a/components/Layout/Docs/index.js
+++ b/components/Layout/Docs/index.js
@@ -7,17 +7,17 @@ import apiContent from "./apiContent.module.css";
 // Makes me realise that this is no so much a layout, as it's a page.
 // It's because the only thing that changes within is the text content
 // and not a sub-layout. Will change it into what it is later.
-const DocsLayout = ({ children }) => (
+const DocsLayout = ({ children, navAPIsList, tocSections }) => (
   <>
     <div className={css.docsPage}>
       <Header serviceName="Connected Documentation" />
       <div className={css.docsPageContent}>
-        <MainSidebar />
+        <MainSidebar navbarItems={navAPIsList} />
         <main className={apiContent.apiItemDocsContainer}>
           <div className={apiContent.row}>
             <div className={`${apiContent.col} ${apiContent.col3of4}`}>{children}</div>
             <div className={`${apiContent.col} ${apiContent.col1of4}`}>
-              <TableOfContents />
+              <TableOfContents tocItems={tocSections} />
             </div>
           </div>
         </main>

--- a/components/Layout/Sidebar/MainSidebar.jsx
+++ b/components/Layout/Sidebar/MainSidebar.jsx
@@ -1,7 +1,8 @@
 import css from "../../../styles/MainSidebar.module.css";
 import HackneyLogo from "../Header/HackneyLogo";
+import Link from "next/link";
 
-const MainSidebar = ({}) => (
+const MainSidebar = ({ navbarItems }) => (
   <aside className={css.sidebarWrapper}>
     <div className={css.sidebar}>
       <a href="/" className={css.sidebarLogo}>
@@ -12,11 +13,11 @@ const MainSidebar = ({}) => (
       </a>
       <nav className={css.apiSelection}>
         <ul className={css.apiNavLinksList}>
-          {[...Array(25).keys()].map((num) => (
-            <li key={num}>
-              <a href="#" className={css.apiLink}>
-                API number {num}
-              </a>
+          {navbarItems?.map((item) => (
+            <li key={item.id}>
+              <Link as={`/api-docs/${item.id}`} href="/api-docs/[id]">
+                <a>{item.name}</a>
+              </Link>
             </li>
           ))}
         </ul>

--- a/components/Layout/Sidebar/TableOfContents.jsx
+++ b/components/Layout/Sidebar/TableOfContents.jsx
@@ -1,6 +1,9 @@
 import css from "../../../styles/TOCSidebar.module.css";
+import Link from "next/link";
 
-const TableOfContents = ({}) => (
+// Should go recursively as the data is nested?
+// But not sure if MVP will contain that
+const TableOfContents = ({ tocItems }) => (
   <div className={css.toc}>
     <div className={css.tocBorder}>
       <p>Toc</p>
@@ -10,9 +13,11 @@ const TableOfContents = ({}) => (
           listStyleType: "none",
         }}
       >
-        {[...Array(10).keys()].map((num) => (
-          <li key={num}>
-            <a href="#">Section {num}</a>
+        {tocItems.map((item) => (
+          <li key={item.name}>
+            <Link href={`#${item.name}`}>
+              <a>{item.name}</a>
+            </Link>
           </li>
         ))}
       </ul>

--- a/components/Loading/Loading.jsx
+++ b/components/Loading/Loading.jsx
@@ -1,0 +1,25 @@
+import utilityCSS from "../../styles/Utility.module.css";
+
+const Loading = () => (
+  <div id={utilityCSS["loading-animation-container"]}>
+    <svg width="50" height="50" viewBox="0 0 42 42" xmlns="http://www.w3.org/2000/svg" stroke="#00703c">
+      <g fill="none" fillRule="evenodd">
+        <g transform="translate(3 3)" strokeWidth="5">
+          <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+          <path d="M36 18c0-9.94-8.06-18-18-18" transform="rotate(0 18 18)">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 18 18"
+              to="360 18 18"
+              dur="1s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </g>
+      </g>
+    </svg>
+  </div>
+);
+
+export default Loading;

--- a/data/abstract/endpointWrapper.js
+++ b/data/abstract/endpointWrapper.js
@@ -1,0 +1,20 @@
+import Response from "./httpResponses";
+
+export default function wrapEndpoint(endpointAction) {
+  return async (req, res) => {
+    const forward = (response) =>
+      res.writeHead(response.statusCode, { ...res.headers, ...response.headers }).end(response.body);
+
+    try {
+      const response = await endpointAction({
+        body: req.body,
+        headers: req.headers,
+        method: req.method,
+        params: req.query,
+      });
+      return forward(response);
+    } catch (err) {
+      return forward(Response.internalServerError());
+    }
+  };
+}

--- a/data/abstract/httpResponses.js
+++ b/data/abstract/httpResponses.js
@@ -1,0 +1,40 @@
+export default class Response {
+  constructor({ statusCode, body, headers = {} }) {
+    this.statusCode = statusCode;
+    this.body = body;
+    this.headers = headers;
+  }
+
+  json(payload) {
+    if (payload) {
+      this.body = JSON.stringify(payload);
+      this.headers["content-type"] = "application/json";
+    }
+
+    return this;
+  }
+
+  static ok(payload) {
+    return new Response({ statusCode: 200 }).json(payload);
+  }
+
+  static created(payload) {
+    return new Response({ statusCode: 201 }).json(payload);
+  }
+
+  static noContent() {
+    return new Response({ statusCode: 204 });
+  }
+
+  static badRequest({ errors }) {
+    return new Response({ statusCode: 400 }).json({ errors });
+  }
+
+  static notAllowed() {
+    return new Response({ statusCode: 405 });
+  }
+
+  static internalServerError() {
+    return new Response({ statusCode: 500 });
+  }
+}

--- a/data/accessMethods.js
+++ b/data/accessMethods.js
@@ -37,7 +37,12 @@ export function queryAPIRecord(relPath, id) {
   return request(concatUrl(relPath, id), { method: "GET" });
 }
 
+export function queryAPIsList(path) {
+  return request(path, { method: "GET" });
+}
+
 module.exports = {
   request,
   queryAPIRecord,
+  queryAPIsList,
 };

--- a/data/accessMethods.js
+++ b/data/accessMethods.js
@@ -32,6 +32,12 @@ async function request(relPath, { ...options }) {
   }
 }
 
+// options, , ...options
+export function queryAPIRecord(relPath, id) {
+  return request(concatUrl(relPath, id), { method: "GET" });
+}
+
 module.exports = {
   request,
+  queryAPIRecord,
 };

--- a/data/accessMethods.js
+++ b/data/accessMethods.js
@@ -9,7 +9,7 @@ const concatUrl = (baseUrl, relPath) => {
 
 //token,
 async function request(relPath, { ...options }) {
-  const serverSideAPIUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
+  const serverSideAPIUrl = "http://localhost:3000/api"; //process.env.NEXT_PUBLIC_API_URL;
   const url = concatUrl(serverSideAPIUrl, relPath);
   console.info(`Fetching ${url}`, options?.body);
   const response = await fetch(url, {

--- a/data/accessMethods.js
+++ b/data/accessMethods.js
@@ -1,0 +1,37 @@
+import HttpStatusError from "./customErrors";
+
+const concatUrl = (baseUrl, relPath) => {
+  const baseEndsWithSlash = baseUrl[baseUrl.length - 1] === "/";
+  const relStartsWithSlash = relPath[0] === "/";
+  const isSlashNeeded = !baseEndsWithSlash && !relStartsWithSlash;
+  return `${baseUrl}${isSlashNeeded ? "/" : ""}${relPath}`;
+};
+
+//token,
+async function request(relPath, { ...options }) {
+  const serverSideAPIUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
+  const url = concatUrl(serverSideAPIUrl, relPath);
+  console.info(`Fetching ${url}`, options?.body);
+  const response = await fetch(url, {
+    ...options,
+    credentials: "same-origin",
+    headers: {
+      accept: "application/json",
+      //   authorization: token ? `Bearer ${token}` : undefined,
+      "content-type": "application/json",
+      //   cookie: `hackneyToken=${token}`,
+    },
+    body: options?.body ? JSON.stringify(options.body) : null,
+  });
+
+  if (response.ok) {
+    return response.json();
+  } else {
+    console.error(`Fetching ${url} failed`, response.status);
+    throw new HttpStatusError(response.status);
+  }
+}
+
+module.exports = {
+  request,
+};

--- a/data/customErrors.js
+++ b/data/customErrors.js
@@ -1,0 +1,6 @@
+export default class HttpStatusError extends Error {
+  constructor(statusCode) {
+    super("Request was not successful");
+    this.statusCode = statusCode;
+  }
+}

--- a/mock-server/dataModels.js
+++ b/mock-server/dataModels.js
@@ -1,9 +1,10 @@
 const randexp = require("randexp").randexp;
 
 class APIRecord {
-  constructor({ key, name, baseUrl, githubUrl, dependencies, status, otherDocumentation }) {
+  constructor({ key, name, githubId, baseUrl, githubUrl, dependencies, status, otherDocumentation }) {
     this.key = key || randexp(/[^\W_]{8}/);
     this.name = name;
+    this.githubId = githubId;
     this.baseUrl = baseUrl;
     this.githubUrl = githubUrl;
     this.dependencies = dependencies;

--- a/mock-server/dataModels.js
+++ b/mock-server/dataModels.js
@@ -1,8 +1,8 @@
 const randexp = require("randexp").randexp;
 
 class APIRecord {
-  constructor({ name, baseUrl, githubUrl, dependencies, status, otherDocumentation }) {
-    this.key = randexp(/[^\W_]{8}/);
+  constructor({ key, name, baseUrl, githubUrl, dependencies, status, otherDocumentation }) {
+    this.key = key || randexp(/[^\W_]{8}/);
     this.name = name;
     this.baseUrl = baseUrl;
     this.githubUrl = githubUrl;

--- a/mock-server/mockServer.js
+++ b/mock-server/mockServer.js
@@ -31,6 +31,18 @@ inMemoryDatabase.apiRecords.slice(1).forEach((r) => {
   });
 });
 
+server.get("/apis", (req, res) => {
+  const apisList = inMemoryDatabase.apiRecords.map((api) => {
+    return {
+      id: api.key,
+      name: api.name,
+      //type? platform/service/etc.
+    };
+  });
+
+  res.status(200).json(apisList);
+});
+
 server.get("/apis/:key", (req, res) => {
   const record = inMemoryDatabase.apiRecords.find((r) => r.key === req.params.key);
 

--- a/mock-server/mockServer.js
+++ b/mock-server/mockServer.js
@@ -22,14 +22,16 @@ server.get(fakeUrl, function (_, res) {
   res.status(302).redirect(`${realUrl}swagger/index.html`);
 });
 
-inMemoryDatabase.apiRecords.slice(1).forEach((r) => {
-  console.log(r.baseUrl.staging);
-  const relativeUrl = r.baseUrl.staging.split(mockServerPort)[1];
-  server.get(relativeUrl, function (_, res) {
-    // for now I only have time to a boring redirect to the same url
-    res.status(302).redirect(`${realUrl}swagger/index.html`);
-  });
-});
+// I think, swagger is using X-Frame-Options header to prevent
+// this from being possible
+// inMemoryDatabase.apiRecords.slice(1).forEach((r) => {
+//   console.log(r.baseUrl.staging);
+//   const relativeUrl = r.baseUrl.staging.split(mockServerPort)[1];
+//   server.get(`${relativeUrl}swagger/index.html`, function (_, res) {
+//     // for now I only have time to a boring redirect to the same url
+//     res.status(302).redirect(`${realUrl}swagger/index.html`);
+//   });
+// });
 
 server.get("/apis", (req, res) => {
   const apisList = inMemoryDatabase.apiRecords.map((api) => {

--- a/mock-server/mockServer.js
+++ b/mock-server/mockServer.js
@@ -31,6 +31,26 @@ inMemoryDatabase.apiRecords.slice(1).forEach((r) => {
   });
 });
 
+server.get("/apis/:key", (req, res) => {
+  const record = inMemoryDatabase.apiRecords.find((r) => r.key === req.params.key);
+
+  setTimeout(() => {
+    if (record) {
+      res.status(200).json(record);
+    } else {
+      res.status(404).end();
+    }
+  }, 2000);
+});
+
+server.post("/residents/:residentId/help_requests/", function (req, res, next) {
+  req.url = "/help_requests";
+  const residentId = parseInt(req.params.residentId);
+  req.params = {};
+  req.body["residentId"] = residentId;
+  next();
+});
+
 server.use(router);
 
 server.listen(mockServerPort, () => {

--- a/mock-server/randomData.js
+++ b/mock-server/randomData.js
@@ -24,7 +24,7 @@ function createRandomAPIRecord(mockServerPort) {
     githubId: randInt(10 ** 9, 10 ** 10 - 1),
     baseUrl: new Environments({
       // swagger/index.html
-      staging: `localhost:${mockServerPort}/mock-endpoint/${randexp(/[^\W_]{12}/)}/`,
+      staging: "https://dr03nduqxh.execute-api.eu-west-2.amazonaws.com/staging/", //`localhost:${mockServerPort}/mock-endpoint/${randexp(/[^\W_]{12}/)}/`,
     }),
     githubUrl: "https://github.com/LBHackney-IT/social-care-case-viewer-api",
     dependencies: new Dependencies({

--- a/mock-server/randomData.js
+++ b/mock-server/randomData.js
@@ -20,6 +20,8 @@ const randInt = (mn, mx) => faker.datatype.number({ min: mn, max: mx });
 
 function createRandomAPIRecord(mockServerPort) {
   return new APIRecord({
+    name: faker.random.words(randInt(3, 5)),
+    githubId: randInt(10 ** 9, 10 ** 10 - 1),
     baseUrl: new Environments({
       // swagger/index.html
       staging: `localhost:${mockServerPort}/mock-endpoint/${randexp(/[^\W_]{12}/)}/`,

--- a/mock-server/testData.js
+++ b/mock-server/testData.js
@@ -13,6 +13,7 @@ const {
 
 // create 1 semi-real as that's the only data I've got currently
 const theOnlyRealRecord = new APIRecord({
+  key: "lbGpbACv",
   name: "Social Care Case Viewer API",
   baseUrl: new Environments({
     // swagger/index.html

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "next": "11.0.1",
     "node-sass": "4.14.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "swr": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/pages/api-docs/[id].js
+++ b/pages/api-docs/[id].js
@@ -1,0 +1,69 @@
+import NonDocsLayout from "../../components/Layout/Non-Docs";
+import DocsLayout from "../../components/Layout/Docs";
+import Loading from "../../components/Loading/Loading";
+import React, { useState, useCallback, useEffect } from "react";
+import useSWR from "swr";
+import { useRouter } from "next/router";
+
+// temp import before I set-up data fetching
+// const { theOnlyRealRecord: record } = require("../../mock-server/testData");
+const { queryAPIRecord, queryAPIsList } = require("../../data/accessMethods");
+
+export default function APIDoc() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  // const id = "lbGpbACv";
+  const { data: singleAPI, error: singleAPIError } = useSWR(["/apis/", id], queryAPIRecord);
+  const { data: navbarList, error: navbarListError } = useSWR(["/apis"], queryAPIsList);
+
+  const tocItems = [...Array(10).keys()].map((num) => {
+    return { name: `Section ${num}` };
+  });
+
+  return (
+    <DocsLayout navAPIsList={navbarList} tocSections={tocItems}>
+      {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
+      <article className="sectionsContainer">
+        {/* Empty marker*/}
+        {singleAPI ? (
+          <>
+            <div className="record-head-container">
+              <div className="api-status">{singleAPI?.status}</div>
+              <h1 className="api-title" style={{ marginTop: "0" }}>
+                {singleAPI?.name}
+              </h1>
+              <span className="environment-selection">
+                <button>Development</button>
+                <button>Staging</button>
+                <button>Production</button>
+              </span>
+            </div>
+            <div class="description-section">
+              <p>{singleAPI?.otherDocumentation.businessContext}</p>
+            </div>
+            <div className="swagger-section">
+              <h2>Swagger Information</h2>
+              <div
+                className="swagger-iframe-container"
+                style={{ width: "100%", paddingRight: "10px", height: "400px", overflow: "hidden" }}
+              >
+                {/* "https://dr03nduqxh.execute-api.eu-west-2.amazonaws.com/staging/swagger/index.html"*/}
+                <iframe
+                  id="swagger-insert"
+                  src={`${singleAPI?.baseUrl.staging}swagger/index.html`}
+                  style={{ width: "100%", height: "420px" }}
+                >
+                  <p>Your browser does not support iframes.</p>
+                </iframe>
+              </div>
+            </div>
+          </>
+        ) : (
+          <Loading />
+        )}
+        {/* Empty marker*/}
+      </article>
+    </DocsLayout>
+  );
+}

--- a/pages/api-docs/index.js
+++ b/pages/api-docs/index.js
@@ -1,0 +1,27 @@
+import DocsLayout from "../../components/Layout/Docs";
+import Loading from "../../components/Loading/Loading";
+import useSWR from "swr";
+
+const { queryAPIsList } = require("../../data/accessMethods");
+
+export default function APIDoc() {
+  const { data: navbarList, error: navbarListError } = useSWR(["/apis"], queryAPIsList);
+
+  const tocItems = [...Array(10).keys()].map((num) => {
+    return { name: `Section ${num}` };
+  });
+
+  return (
+    <DocsLayout navAPIsList={navbarList} tocSections={tocItems}>
+      {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
+      <article className="sectionsContainer">
+        {/* Empty marker*/}
+        <p>
+          Do you think this could be the D3 page? Thinking about the D3 page, This will require the adding of dependecy
+          API property.
+        </p>
+        {/* Empty marker*/}
+      </article>
+    </DocsLayout>
+  );
+}

--- a/pages/api/api-docs/[id].js
+++ b/pages/api/api-docs/[id].js
@@ -1,0 +1,20 @@
+import wrapEndpoint from "../../../data/abstract/endpointWrapper";
+import Response from "../../../data/abstract/httpResponses";
+
+export default wrapEndpoint(async ({ params: { id }, headers }) => {
+  const apiBaseUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
+  const apiCallResponse = await fetch(`${apiBaseUrl}/apis/${id}`);
+  let nextServerResponseData;
+
+  if (apiCallResponse.ok) {
+    const apiDocRecord = await Promise.resolve(apiCallResponse.json());
+    nextServerResponseData = { data: apiDocRecord };
+  } else {
+    const errMsg = "Error happened while retrieving API Record";
+    console.log(errMsg, apiCallResponse.status);
+    nextServerResponseData = { data: [], error: errMsg };
+  }
+
+  return Response.ok(nextServerResponseData);
+});
+

--- a/pages/api/apis/[id].js
+++ b/pages/api/apis/[id].js
@@ -17,4 +17,3 @@ export default wrapEndpoint(async ({ params: { id }, headers }) => {
 
   return Response.ok(nextServerResponseData);
 });
-

--- a/pages/api/apis/[id].js
+++ b/pages/api/apis/[id].js
@@ -12,7 +12,7 @@ export default wrapEndpoint(async ({ params: { id }, headers }) => {
   } else {
     const errMsg = "Error happened while retrieving API Record";
     console.log(errMsg, apiCallResponse.status);
-    nextServerResponseData = { data: [], error: errMsg };
+    nextServerResponseData = { data: null, error: errMsg };
   }
 
   return Response.ok(nextServerResponseData);

--- a/pages/api/apis/[id].js
+++ b/pages/api/apis/[id].js
@@ -4,16 +4,13 @@ import Response from "../../../data/abstract/httpResponses";
 export default wrapEndpoint(async ({ params: { id }, headers }) => {
   const apiBaseUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
   const apiCallResponse = await fetch(`${apiBaseUrl}/apis/${id}`);
-  let nextServerResponseData;
 
   if (apiCallResponse.ok) {
     const apiDocRecord = await Promise.resolve(apiCallResponse.json());
-    nextServerResponseData = { data: apiDocRecord };
+    return Response.ok(apiDocRecord);
   } else {
     const errMsg = "Error happened while retrieving API Record";
     console.log(errMsg, apiCallResponse.status);
-    nextServerResponseData = { data: null, error: errMsg };
+    return Response.internalServerError();
   }
-
-  return Response.ok(nextServerResponseData);
 });

--- a/pages/api/apis/index.js
+++ b/pages/api/apis/index.js
@@ -1,0 +1,20 @@
+import wrapEndpoint from "../../../data/abstract/endpointWrapper";
+import Response from "../../../data/abstract/httpResponses";
+
+export default wrapEndpoint(async ({ headers }) => {
+  const apiBaseUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
+  const apiCallResponse = await fetch(`${apiBaseUrl}/apis`);
+  let nextServerResponseData;
+
+  if (apiCallResponse.ok) {
+    const apisList = await Promise.resolve(apiCallResponse.json());
+    nextServerResponseData = { data: apisList };
+  } else {
+    const errMsg = "Error happened while retrieving API Records List";
+    console.log(errMsg, apiCallResponse.status);
+    nextServerResponseData = { data: [], error: errMsg };
+  }
+
+  return Response.ok(nextServerResponseData);
+});
+

--- a/pages/api/apis/index.js
+++ b/pages/api/apis/index.js
@@ -4,17 +4,13 @@ import Response from "../../../data/abstract/httpResponses";
 export default wrapEndpoint(async ({ headers }) => {
   const apiBaseUrl = "http://localhost:4000"; //process.env.NEXT_PUBLIC_API_URL;
   const apiCallResponse = await fetch(`${apiBaseUrl}/apis`);
-  let nextServerResponseData;
 
   if (apiCallResponse.ok) {
     const apisList = await Promise.resolve(apiCallResponse.json());
-    nextServerResponseData = { data: apisList };
+    return Response.ok(apisList);
   } else {
     const errMsg = "Error happened while retrieving API Records List";
     console.log(errMsg, apiCallResponse.status);
-    nextServerResponseData = { data: [], error: errMsg };
+    return Response.internalServerError();
   }
-
-  return Response.ok(nextServerResponseData);
 });
-

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -2,5 +2,7 @@ import wrapEndpoint from "../../data/abstract/endpointWrapper";
 import Response from "../../data/abstract/httpResponses";
 
 export default wrapEndpoint(() => {
-  return Response.noContent();
+  return Response.ok({
+    uzo: "hello!",
+  });
 });

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,5 +1,6 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import wrapEndpoint from "../../data/abstract/endpointWrapper";
+import Response from "../../data/abstract/httpResponses";
 
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}
+export default wrapEndpoint(() => {
+  return Response.noContent();
+});

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,11 +29,9 @@ const { queryAPIRecord } = require("../data/accessMethods");
 
 // };
 
-queryAPIRecord;
-
 export default function Home() {
   const id = "lbGpbACv";
-  const { data, error } = useSWR(["/apis/", id], queryAPIRecord);
+  const { data, error } = useSWR(["/api-docs/", id], queryAPIRecord);
   return (
     <DocsLayout>
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,11 @@
 import NonDocsLayout from "../components/Layout/Non-Docs";
 import DocsLayout from "../components/Layout/Docs";
 import React, { useState, useCallback, useEffect } from "react";
+import useSWR from "swr";
+
 // temp import before I set-up data fetching
 const { theOnlyRealRecord: record } = require("../mock-server/testData");
+const { queryAPIRecord } = require("../data/accessMethods");
 
 // const [status, setStatus] = useState();
 
@@ -26,13 +29,17 @@ const { theOnlyRealRecord: record } = require("../mock-server/testData");
 
 // };
 
+queryAPIRecord;
+
 export default function Home() {
-  // console.log(tempObject);
+  const id = "lbGpbACv";
+  const { data, error } = useSWR(["/apis/", id], queryAPIRecord);
   return (
     <DocsLayout>
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
       <article className="sectionsContainer">
         {/* Empty marker*/}
+        <p>{data ? <em>{JSON.stringify(data)}</em> : <h1>loading</h1>}</p>
         <div className="record-head-container">
           <div className="api-status">{record.status}</div>
           <h1 className="api-title" style={{ marginTop: "0" }}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,39 +5,20 @@ import useSWR from "swr";
 
 // temp import before I set-up data fetching
 const { theOnlyRealRecord: record } = require("../mock-server/testData");
-const { queryAPIRecord } = require("../data/accessMethods");
-
-// const [status, setStatus] = useState();
-
-// Change of approach, but this might still be useful
-// const getNodeKey = (level, title, markdown) => `${level}-${title}-${markdown ? markdown.length : 0}`;
-// // I want to keep the name docTree for descriptiveness
-// function markUpDocTree(docTree, level = 1) {
-//   const { title, markdown, sections } = docTree;
-//   const nodeJSX = (
-//     <div key={getNodeKey(level, title, markdown)} className="layeredSection">
-//       <HeadingN n={level}>{title}</HeadingN>
-//       {markdown && <p>{markdown}</p>}
-//       {sections && sections.map((node) => markUpDocTree(node, level + 1))}
-//     </div>
-//   );
-//   return nodeJSX;
-// }
-//markUpDocTree(tempObject)
-
-// const parseAPIDataIntoReact = () => {
-
-// };
+const { queryAPIRecord, queryAPIsList } = require("../data/accessMethods");
 
 export default function Home() {
   const id = "lbGpbACv";
-  const { data, error } = useSWR(["/apis/", id], queryAPIRecord);
+  const { data: singleAPI, error: singleAPIError } = useSWR(["/apis/", id], queryAPIRecord);
+  const { data: navbarList, error: navbarListError } = useSWR(["/apis"], queryAPIsList);
   return (
     <DocsLayout>
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
       <article className="sectionsContainer">
         {/* Empty marker*/}
-        <p>{data ? <em>{JSON.stringify(data)}</em> : <h1>loading</h1>}</p>
+        <p>{singleAPI ? <em>{JSON.stringify(singleAPI)}</em> : <h1>loading</h1>}</p>
+        <p>-----------------------------------------------------------------------</p>
+        <p>{navbarList ? <em>{JSON.stringify(navbarList)}</em> : <h1>loading</h1>}</p>
         <div className="record-head-container">
           <div className="api-status">{record.status}</div>
           <h1 className="api-title" style={{ marginTop: "0" }}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import NonDocsLayout from "../components/Layout/Non-Docs";
 import DocsLayout from "../components/Layout/Docs";
+import Loading from "../components/Loading/Loading";
 import React, { useState, useCallback, useEffect } from "react";
 import useSWR from "swr";
 
@@ -17,7 +18,7 @@ export default function Home() {
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
       <article className="sectionsContainer">
         {/* Empty marker*/}
-        <p>{singleAPI ? <em>{JSON.stringify(singleAPI)}</em> : <h1>loading</h1>}</p>
+        <p>{singleAPI ? <em>{JSON.stringify(singleAPI)}</em> : <Loading />}</p>
         <p>-----------------------------------------------------------------------</p>
         <p>{navbarList ? <em>{JSON.stringify(navbarList)}</em> : <h1>loading</h1>}</p>
         <div className="record-head-container">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,58 +1,24 @@
 import NonDocsLayout from "../components/Layout/Non-Docs";
-import DocsLayout from "../components/Layout/Docs";
 import Loading from "../components/Loading/Loading";
 import React, { useState, useCallback, useEffect } from "react";
 import useSWR from "swr";
-
-// temp import before I set-up data fetching
-const { theOnlyRealRecord: record } = require("../mock-server/testData");
-const { queryAPIRecord, queryAPIsList } = require("../data/accessMethods");
+import Link from "next/link";
 
 export default function Home() {
-  const id = "lbGpbACv";
-  const { data: singleAPI, error: singleAPIError } = useSWR(["/apis/", id], queryAPIRecord);
-  const { data: navbarList, error: navbarListError } = useSWR(["/apis"], queryAPIsList);
-
   return (
-    <DocsLayout>
-      {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}
+    <NonDocsLayout>
       <article className="sectionsContainer">
-        {/* Empty marker*/}
-        <p>{singleAPI ? <em>{JSON.stringify(singleAPI)}</em> : <Loading />}</p>
-        <p>-----------------------------------------------------------------------</p>
-        <p>{navbarList ? <em>{JSON.stringify(navbarList)}</em> : <h1>loading</h1>}</p>
-        <div className="record-head-container">
-          <div className="api-status">{record.status}</div>
-          <h1 className="api-title" style={{ marginTop: "0" }}>
-            {record.name}
-          </h1>
-          <span className="environment-selection">
-            <button>Development</button>
-            <button>Staging</button>
-            <button>Production</button>
-          </span>
-        </div>
-        <div class="description-section">
-          <p>{record.otherDocumentation.businessContext}</p>
-        </div>
-        <div className="swagger-section">
-          <h2>Swagger Information</h2>
-          <div
-            className="swagger-iframe-container"
-            style={{ width: "100%", paddingRight: "10px", height: "400px", overflow: "hidden" }}
-          >
-            {/* "https://dr03nduqxh.execute-api.eu-west-2.amazonaws.com/staging/swagger/index.html"*/}
-            <iframe
-              id="swagger-insert"
-              src={`${record.baseUrl.staging}swagger/index.html`}
-              style={{ width: "100%", height: "420px" }}
-            >
-              <p>Your browser does not support iframes.</p>
-            </iframe>
-          </div>
-        </div>
-        {/* Empty marker*/}
+        <p>
+          Description text of this service. Description text of this service. Description text of this service.
+          Description text of this service. Description text of this service. Description text of this service.{" "}
+          Description text of this service. Description text of this service. Description text of this service.{" "}
+        </p>
+        <br />
+
+        <Link href={"/api-docs"}>
+          <a>API Docs, well the link could be fancier</a>
+        </Link>
       </article>
-    </DocsLayout>
+    </NonDocsLayout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,6 +11,7 @@ export default function Home() {
   const id = "lbGpbACv";
   const { data: singleAPI, error: singleAPIError } = useSWR(["/apis/", id], queryAPIRecord);
   const { data: navbarList, error: navbarListError } = useSWR(["/apis"], queryAPIsList);
+
   return (
     <DocsLayout>
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,7 +31,7 @@ const { queryAPIRecord } = require("../data/accessMethods");
 
 export default function Home() {
   const id = "lbGpbACv";
-  const { data, error } = useSWR(["/api-docs/", id], queryAPIRecord);
+  const { data, error } = useSWR(["/apis/", id], queryAPIRecord);
   return (
     <DocsLayout>
       {/* Not sure yet if there's any point to having this container tempObject && tempObject.map(node => )*/}

--- a/styles/Utility.module.css
+++ b/styles/Utility.module.css
@@ -1,0 +1,5 @@
+#loading-animation-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/utilities/markdownParser.js
+++ b/utilities/markdownParser.js
@@ -71,3 +71,25 @@ splitOutTopLevelEmphasis(emphasisOverload);
 // Answer is yes, because of runaway regular expressions: (?<![_*])(_|\*)[^ \n]([^\n]+)(\n?[^_*\n]+?)+\1(?![_*])
 // It's already inefficient as hell to do this in regex, but with all the back-tracking it just becomes ridiculous
 // Maybe... not sure yet - I found a way around the catastrophic backtracking.
+
+// const [status, setStatus] = useState();
+
+// Change of approach, but this might still be useful
+// const getNodeKey = (level, title, markdown) => `${level}-${title}-${markdown ? markdown.length : 0}`;
+// // I want to keep the name docTree for descriptiveness
+// function markUpDocTree(docTree, level = 1) {
+//   const { title, markdown, sections } = docTree;
+//   const nodeJSX = (
+//     <div key={getNodeKey(level, title, markdown)} className="layeredSection">
+//       <HeadingN n={level}>{title}</HeadingN>
+//       {markdown && <p>{markdown}</p>}
+//       {sections && sections.map((node) => markUpDocTree(node, level + 1))}
+//     </div>
+//   );
+//   return nodeJSX;
+// }
+//markUpDocTree(tempObject)
+
+// const parseAPIDataIntoReact = () => {
+
+// };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,11 @@ depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -4751,6 +4756,13 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+swr@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.0.tgz#d047933714d8bd16ae35af67d81149f4ae700a4d"
+  integrity sha512-v55Dr+vxIFiUyGxC5W4uN5falxHxYdbpb/R3bO+bSG+svbC9bUWmupy4NM/2pER7X8OvgwJWu0AiSoGy0ND9ew==
+  dependencies:
+    dequal "2.0.2"
 
 table@^6.0.9:
   version "6.7.1"


### PR DESCRIPTION
# What:
 - Wired up the front-end to retrieving the data it needs through server-side calls.
 - Wired up the props paths to populate the sidebars with data coming from the main page.
 - Changed mock base URLs to be the only real URL due to redirects not getting picked up by iframe.
 - Moved the API Docs page to the appropriate folder location & added placeholder pages where needed.

# Why:
 - Doing calls through server-side for increased security so that the user wouldn't be able to examine the API call headers & see the API key in there.
 - Made the Navbar and TOCbar components populated through props from the base page as I'm following smart and dumb components pattern.
 - Iframe doesn't not seem to be working with redirects. It's likely related to X-Frame-Options header, which is something beyond my control. Regardless, it's not a huge problem as it's dummy data anyway.
 - Moved API docs page to appropriate place so that I could take advantage of Next.js routing & be able to easily access the path parameters with useRouter.
 - Created a placeholder home page as something needs to take place of the now moved API docs page.
 - Created a placeholder API docs entry page so that the user wouldn't get abruptly dropped in into some API.

# Notes:
 - Made use of 'useSwr' library, which makes data fetching & displaying loading state much easier. Also it's nice that it takes care of re-fetching the data once the tab gets focused again.